### PR TITLE
Fix: Pagination

### DIFF
--- a/gdrivefs/core.py
+++ b/gdrivefs/core.py
@@ -194,7 +194,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
                 all_files.append(_finfo_from_response(f, path_prefix))
             more = response.get('incompleteSearch', False)
             page_token = response.get('nextPageToken', None)
-            if page_token is None or more is False:
+            if page_token is None and more is False:
                 break
         return all_files
 


### PR DESCRIPTION
The pagination should stop only when the `nextPageToken` field is missing and the `incompleteSearch` is False
Fixes #30 