### PR TITLE
Fix service_account connections

### DIFF
--- a/gdrivefs/core.py
+++ b/gdrivefs/core.py
@@ -88,7 +88,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             cred = self._connect_cache()
         elif method == 'anon':
             cred = AnonymousCredentials()
-        elif method is "service_account":
+        elif method == "service_account":
             cred = self._connect_service_account()
         else:
             raise ValueError(f"Invalid connection method `{method}`.")


### PR DESCRIPTION
There is a small bug in `connect()`:

```python
        elif method is "service_account":
            cred = self._connect_service_account()
```

attempting to authenticate with `token="service_account"` generates an error like:

```
hea-dagster_daemon-1  | ValueError: Invalid connection method `service_account`.
hea-dagster_daemon-1  | 
hea-dagster_daemon-1  | Stack Trace:
hea-dagster_daemon-1  |     with p.fs.open(p.path, mode="rb", cache_type="bytes") as f:
hea-dagster_daemon-1  |          ^^^^
hea-dagster_daemon-1  |   File "/usr/local/lib/python3.12/site-packages/upath/core.py", line 251, in fs
hea-dagster_daemon-1  |     fs = self._fs_cached = self._fs_factory(
hea-dagster_daemon-1  |                            ^^^^^^^^^^^^^^^^^
hea-dagster_daemon-1  |   File "/usr/local/lib/python3.12/site-packages/upath/core.py", line 302, in _fs_factory
hea-dagster_daemon-1  |     return fs_cls(**storage_options)
hea-dagster_daemon-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
hea-dagster_daemon-1  |   File "/usr/local/lib/python3.12/site-packages/fsspec/spec.py", line 80, in __call__
hea-dagster_daemon-1  |     obj = super().__call__(*args, **kwargs)
hea-dagster_daemon-1  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
hea-dagster_daemon-1  |   File "/usr/local/lib/python3.12/site-packages/gdrivefs/core.py", line 82, in __init__
hea-dagster_daemon-1  |     self.connect(method=token)
hea-dagster_daemon-1  |   File "/usr/local/lib/python3.12/site-packages/gdrivefs/core.py", line 94, in connect
hea-dagster_daemon-1  |     raise ValueError(f"Invalid connection method `{method}`.")
```

Changing from `elif method is "service_account":` to `elif method == "service_account":` fixes this problem.