### PR TITLE
add auth kwargs parameter

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,8 @@ jobs:
       env:
         GDRIVE_FSSPEC_DRIVE: gdrivefs-testing
         GDRIVE_FSSPEC_CREDENTIALS_PATH: ${{ secrets.GDRIVE_FSSPEC_CREDENTIALS_PATH }}
-      run: pytest -vv
+      # Override the default marker filter so CI runs integration tests too.
+      run: pytest -vv -m ""
 
   lint:
     name: lint

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As gdrivefs implements the fsspec interface, most documentation can be found at 
 
 There are several methods to authenticate gdrivefs against Google Drive.
 
-1. Service account credentials
+#### 1. Service account credentials
 
 In this method, you provide a dict containing the service account credentials obtained
 in the GCP console. The dict content is the same as the JSON file downloaded from the GCP console.
@@ -36,9 +36,9 @@ fs = GoogleDriveFileSystem(creds=service_account_credentials,
                            token="service_account")
 ```
 
-2. OAuth with user credentials
+#### 2. OAuth with user credentials
 
- A browser will be opened to complete the OAuth authentication flow. Afterwards, the access
+A browser will be opened to complete the OAuth authentication flow. Afterwards, the access
 token will be stored locally, and you can reuse it in subsequent sessions.
 
 ```python
@@ -47,9 +47,21 @@ token = 'browser'
 # use this on subsequent attempts
 # token = 'cache'
 fs = GoogleDriveFileSystem(token=token)
- ```
+```
 
-3. Anonymous (read-only) access
+On headless or remote machines (SSH sessions, containers, CI, and similar environments),
+you may not be able to bind a local callback server or open a browser on the same host.
+In that case, pass `use_local_webserver: False` in `auth_kwargs` to request a token via
+the console.
+
+```python
+fs = GoogleDriveFileSystem(
+    token=token,
+    auth_kwargs={'use_local_webserver': False},
+)
+```
+
+#### 3. Anonymous (read-only) access
 
 If you want to interact with files that are shared publicly ("anyone with the link"),
 then you do not need to authenticate to Google Drive.

--- a/gdrive_fsspec/core.py
+++ b/gdrive_fsspec/core.py
@@ -102,7 +102,12 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             The files need to be shared with the service account email address, that can be found
             in the json file.
         :param auth_kwargs: dict
-            Additional keyword arguments to pass to the authentication method.
+            Additional keyword arguments passed to the authentication backend
+            (``pydata_google_auth.get_user_credentials`` for user OAuth, or
+            ``service_account.Credentials.from_service_account_info`` for service
+            accounts). For headless or remote environments where a local callback
+            server is unavailable, pass ``use_local_webserver=False`` to request a
+            token via the console.
         :param kwargs:
             Passed to parent
         """

--- a/gdrive_fsspec/core.py
+++ b/gdrive_fsspec/core.py
@@ -153,16 +153,10 @@ class GoogleDriveFileSystem(AbstractFileSystem):
     def _connect_cache(self):
         import pydata_google_auth
 
-        return pydata_google_auth.get_user_credentials(
-            self.scopes, use_local_webserver=True, **self.auth_kwargs
-        )
+        kwargs = {"use_local_webserver": True, **self.auth_kwargs}
+        return pydata_google_auth.get_user_credentials(self.scopes, **kwargs)
 
     def _connect_service_account(self):
-        if self.creds is None:
-            raise ValueError(
-                "Service account credentials are required when token='service_account'. "
-                "Pass creds as a dict or path to a credentials JSON file."
-            )
         if isinstance(self.creds, str):
             if self.creds[0] != "{":
                 creds = json.load(open(self.creds))

--- a/gdrive_fsspec/core.py
+++ b/gdrive_fsspec/core.py
@@ -103,7 +103,6 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             in the json file.
         :param auth_kwargs: dict
             Additional keyword arguments to pass to the authentication method.
-            Currently only used for the "cache" and "browser" methods.
         :param kwargs:
             Passed to parent
         """
@@ -165,7 +164,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
         else:
             creds = self.creds
         return service_account.Credentials.from_service_account_info(
-            info=creds, scopes=self.scopes
+            info=creds, scopes=self.scopes, **self.auth_kwargs
         )
 
     @cached_property

--- a/gdrive_fsspec/core.py
+++ b/gdrive_fsspec/core.py
@@ -76,6 +76,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
         spaces="drive",
         creds=None,
         drive=None,
+        auth_kwargs=None,
         **kwargs,
     ):
         """
@@ -100,6 +101,9 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             don't want the user to be prompted to authenticate.
             The files need to be shared with the service account email address, that can be found
             in the json file.
+        :param auth_kwargs: dict
+            Additional keyword arguments to pass to the authentication method.
+            Currently only used for the "cache" and "browser" methods.
         :param kwargs:
             Passed to parent
         """
@@ -108,6 +112,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
         self.scopes = [scope_dict[access]]
         self.spaces = spaces
         self.creds = creds
+        self.auth_kwargs = auth_kwargs or {}
         self.connect(method=token)
         if token == "anon":
             self.drive = None
@@ -149,10 +154,15 @@ class GoogleDriveFileSystem(AbstractFileSystem):
         import pydata_google_auth
 
         return pydata_google_auth.get_user_credentials(
-            self.scopes, use_local_webserver=True
+            self.scopes, use_local_webserver=True, **self.auth_kwargs
         )
 
     def _connect_service_account(self):
+        if self.creds is None:
+            raise ValueError(
+                "Service account credentials are required when token='service_account'. "
+                "Pass creds as a dict or path to a credentials JSON file."
+            )
         if isinstance(self.creds, str):
             if self.creds[0] != "{":
                 creds = json.load(open(self.creds))

--- a/gdrive_fsspec/tests/test_core.py
+++ b/gdrive_fsspec/tests/test_core.py
@@ -16,7 +16,7 @@ kwargs = {
 def _credentials_configured():
     token = os.getenv("GDRIVE_FSSPEC_CREDENTIALS_TYPE", "service_account")
     if token == "service_account":
-        return os.getenv("GDRIVE_FSSPEC_CREDENTIALS_PATH") is not None
+        return bool(os.getenv("GDRIVE_FSSPEC_CREDENTIALS_PATH"))
     return True
 
 

--- a/gdrive_fsspec/tests/test_core.py
+++ b/gdrive_fsspec/tests/test_core.py
@@ -13,8 +13,17 @@ kwargs = {
 }
 
 
+def _credentials_configured():
+    token = os.getenv("GDRIVE_FSSPEC_CREDENTIALS_TYPE", "service_account")
+    if token == "service_account":
+        return os.getenv("GDRIVE_FSSPEC_CREDENTIALS_PATH") is not None
+    return True
+
+
 @pytest.fixture()
 def fs():
+    if not _credentials_configured():
+        pytest.skip("GDRIVE_FSSPEC_CREDENTIALS_PATH not set")
     fs = gdrive_fsspec.GoogleDriveFileSystem(**kwargs)
     if fs.exists(testdir):
         fs.rm(testdir, recursive=True)
@@ -33,6 +42,7 @@ def test_create_anon():
     assert fs.srv is not None
 
 
+@pytest.mark.integration
 def test_simple(fs):
     assert fs.ls("")
     data = b"hello"
@@ -42,6 +52,7 @@ def test_simple(fs):
     assert fs.cat(fn) == data
 
 
+@pytest.mark.integration
 def test_create_directory(fs):
     fs.makedirs(testdir + "/data")
     fs.makedirs(testdir + "/data/bar/baz")
@@ -54,3 +65,11 @@ def test_create_directory(fs):
     with fs.open(testdir + "/data/bar/test", "wb") as f:
         f.write(data)
     assert fs.cat(testdir + "/data/bar/test") == data
+
+
+def test_auth_kwargs():
+    fs = gdrive_fsspec.GoogleDriveFileSystem(
+        token="anon", auth_kwargs={"user_email": "test@example.com"}
+    )
+    assert fs.srv is not None
+    assert fs.auth_kwargs == {"user_email": "test@example.com"}


### PR DESCRIPTION
Fixes https://github.com/fsspec/gdrive-fsspec/issues/54.

I opted for a flexible API, but I don't have strong opinions & willing to change. Also fixed running the tests without credentials.

Now I can run the following code in a remote notebook environment
```python
fs = GoogleDriveFileSystem(token="browser", use_listings_cache=False, auth_kwargs={"use_local_webserver": False})
```

<img width="880" height="210" alt="image" src="https://github.com/user-attachments/assets/fdb1858b-2601-49c2-ac4d-2e21c00235a2" />

I might need to fix the test in CI.