### PR TITLE
Allow listing an empty drive root

### DIFF
--- a/src/gdrive_fsspec/core.py
+++ b/src/gdrive_fsspec/core.py
@@ -281,6 +281,14 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             files = self._list_directory_by_id(
                 file_id, trashed=trashed, path_prefix=pref
             )
+            if (
+                path == ""
+                and not files
+                and self.drive is None
+                and file_id != "root"
+                and not self._file_id_exists(file_id)
+            ):
+                raise FileNotFoundError(path)
             if files or path == "":
                 self.dircache[pref] = files
             else:
@@ -315,6 +323,17 @@ class GoogleDriveFileSystem(AbstractFileSystem):
                 "id": self.root_file_id,
             }
         return super().info(path, trashed=trashed)
+
+    def _file_id_exists(self, file_id):
+        try:
+            self.files.get(
+                fileId=file_id, supportsAllDrives=True, fields="id"
+            ).execute()
+        except HttpError as e:
+            if e.resp.status == 404:
+                return False
+            raise
+        return True
 
     def _drive_kw(self):
         if self.drive is not None:

--- a/src/gdrive_fsspec/core.py
+++ b/src/gdrive_fsspec/core.py
@@ -281,7 +281,7 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             files = self._list_directory_by_id(
                 file_id, trashed=trashed, path_prefix=pref
             )
-            if files:
+            if files or path == "":
                 self.dircache[pref] = files
             else:
                 raise FileNotFoundError(path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -197,6 +197,25 @@ def test_ls_empty_root(anon_fs):
     assert anon_fs.dircache[""] == []
 
 
+def test_ls_empty_custom_root(anon_fs):
+    anon_fs.root_file_id = "empty-root"
+    anon_fs._list_directory_by_id = mock.Mock(return_value=[])
+    anon_fs._file_id_exists = mock.Mock(return_value=True)
+
+    assert anon_fs.ls("") == []
+    assert anon_fs.dircache[""] == []
+
+
+def test_ls_missing_custom_root(anon_fs):
+    anon_fs.root_file_id = "missing-root"
+    anon_fs._list_directory_by_id = mock.Mock(return_value=[])
+    anon_fs._file_id_exists = mock.Mock(return_value=False)
+
+    with pytest.raises(FileNotFoundError):
+        anon_fs.ls("")
+    assert "" not in anon_fs.dircache
+
+
 def test_ls_missing_path_on_empty_root(anon_fs):
     anon_fs._list_directory_by_id = mock.Mock(return_value=[])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -190,6 +190,20 @@ def test_invalidate_cache_all(anon_fs):
     assert anon_fs.dircache == {}
 
 
+def test_ls_empty_root(anon_fs):
+    anon_fs._list_directory_by_id = mock.Mock(return_value=[])
+
+    assert anon_fs.ls("") == []
+    assert anon_fs.dircache[""] == []
+
+
+def test_ls_missing_path_on_empty_root(anon_fs):
+    anon_fs._list_directory_by_id = mock.Mock(return_value=[])
+
+    with pytest.raises(FileNotFoundError):
+        anon_fs.ls("missing")
+
+
 def test_drive_id_from_name_single_match(anon_fs):
     anon_fs.drives = [{"id": "1", "name": "foo"}, {"id": "2", "name": "bar"}]
     assert anon_fs._drive_id_from_name("foo") == "1"


### PR DESCRIPTION
## Summary
- treat an empty top-level Drive listing as an empty directory instead of a missing path
- keep `FileNotFoundError` for missing non-root paths
- add unit tests for both paths

## Tests
- `.venv/bin/python -m pytest -q`
- `.venv/bin/pre-commit run --files gdrive_fsspec/core.py tests/test_core.py`

Fixes #59

AI assistance was used under my direction.