### PR TITLE
Implement directory cache invalidation

### DIFF
--- a/gdrive_fsspec/core.py
+++ b/gdrive_fsspec/core.py
@@ -237,6 +237,13 @@ class GoogleDriveFileSystem(AbstractFileSystem):
             raise ValueError("Path is not a directory")
         self.rm(path, recursive=False)
 
+    def invalidate_cache(self, path=None):
+        if path is None:
+            self.dircache.clear()
+        else:
+            self.dircache.pop(self._strip_protocol(path), None)
+        super().invalidate_cache(path)
+
     def export(self, path, mime_type):
         """Convert a google-native file to another format and download
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -146,6 +146,25 @@ def test_root_info(anon_fs):
     assert info["id"] == anon_fs.root_file_id
 
 
+def test_invalidate_cache_path(anon_fs):
+    anon_fs.dircache["parent"] = [{"name": "parent/file"}]
+    anon_fs.dircache["other"] = [{"name": "other/file"}]
+
+    anon_fs.invalidate_cache("parent")
+
+    assert "parent" not in anon_fs.dircache
+    assert anon_fs.dircache["other"] == [{"name": "other/file"}]
+
+
+def test_invalidate_cache_all(anon_fs):
+    anon_fs.dircache["parent"] = [{"name": "parent/file"}]
+    anon_fs.dircache["other"] = [{"name": "other/file"}]
+
+    anon_fs.invalidate_cache()
+
+    assert anon_fs.dircache == {}
+
+
 def test_drive_id_from_name_single_match(anon_fs):
     anon_fs.drives = [{"id": "1", "name": "foo"}, {"id": "2", "name": "bar"}]
     assert anon_fs._drive_id_from_name("foo") == "1"


### PR DESCRIPTION
Summary:
- Add GoogleDriveFileSystem.invalidate_cache() to clear all cached listings or one cached path.
- Keep the parent fsspec invalidation hook for transaction handling.
- Add regression tests for path-specific and full cache invalidation.

Tests:
- RED before fix: .venv/bin/python -m pytest tests/test_core.py -q failed on the new invalidate_cache tests.
- .venv/bin/python -m pytest tests/test_core.py -q
- .venv/bin/python -m pytest -q
- .venv/bin/pre-commit run --files gdrive_fsspec/core.py tests/test_core.py
- git diff --check

Fixes #62

AI assistance was used under my direction.